### PR TITLE
Add Cloudflare Turnstile integration for CAPTCHA verification

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,8 @@
     "react-big-calendar": "^1.19.4",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "react-turnstile": "^1.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/components/AuthModal.jsx
+++ b/client/src/components/AuthModal.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { FaTimes, FaGoogle, FaUniversity } from 'react-icons/fa';
 import { motion, AnimatePresence } from 'framer-motion';
 import '../styles/AuthModal.css';
+import Turnstile from "react-turnstile";
 
+const siteKey = import.meta.env.VITE_CLOUDFLARE_TURNSTILE_SITE;
 const AuthModal = ({ isOpen, onClose, onAuthSuccess }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -17,8 +19,14 @@ const AuthModal = ({ isOpen, onClose, onAuthSuccess }) => {
   const handleGoogleLogin = () => {
     setLoading(true);
     setError('');
-    sessionStorage.removeItem('oauth_processed');
-    window.location.href = '/api/auth/google';
+    const turnstileToken = sessionStorage.getItem("cf_turnstile_token");
+
+    if (!turnstileToken) {
+      setLoading(false);
+      setError("Please complete CAPTCHA first.");
+      return;
+    }
+    window.location.href = `/api/auth/google?cf_token=${turnstileToken}`;
   };
 
   const resetForm = () => {
@@ -60,6 +68,12 @@ const AuthModal = ({ isOpen, onClose, onAuthSuccess }) => {
               <div className="auth-description">
                 <FaUniversity className="university-icon" />
                 <h3>University of Minnesota Students Only</h3>
+                <Turnstile
+                  sitekey={siteKey}
+                  onVerify={(token) => {
+                    sessionStorage.setItem("cf_turnstile_token", token);
+                  }}
+                />
                 <p>Sign in with your UMN Google account to access the platform</p>
               </div>
 

--- a/client/src/styles/AuthModal.css
+++ b/client/src/styles/AuthModal.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 100000;
   backdrop-filter: blur(4px);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       react-router-dom:
         specifier: ^7.6.2
         version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-turnstile:
+        specifier: ^1.1.4
+        version: 1.1.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.0
@@ -1566,6 +1569,12 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-turnstile@1.1.4:
+    resolution: {integrity: sha512-oluyRWADdsufCt5eMqacW4gfw8/csr6Tk+fmuaMx0PWMKP1SX1iCviLvD2D5w92eAzIYDHi/krUWGHhlfzxTpQ==}
+    peerDependencies:
+      react: '>= 16.13.1'
+      react-dom: '>= 16.13.1'
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
@@ -3247,6 +3256,11 @@ snapshots:
       react: 19.1.0
       set-cookie-parser: 2.7.1
     optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
+  react-turnstile@1.1.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}


### PR DESCRIPTION
- prompt for CLOUDFLARE_TURNSTILE_SITE (site key) and CLOUDFLARE_TURNSTILE_SECRET (secret key) during setup
- update AuthModal to use site key from env
- add Turnstile verification step in auth routes
